### PR TITLE
[Feature/Exchange] "Screen 3 – Exchange (Crypto ↔ Fiat)"

### DIFF
--- a/src/components/AppButtonIcon/index.tsx
+++ b/src/components/AppButtonIcon/index.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { TouchableOpacity } from 'react-native';
+
+import AppIcon from 'components/AppIcon';
+import { MARINER } from 'constants/colors';
+
+type Props = {
+  onPress: () => void;
+  name: string;
+  size?: number;
+  color?: string;
+};
+
+const AppButtonIcon = ({
+  onPress,
+  name,
+  size = 24,
+  color = MARINER,
+}: Props) => (
+  <TouchableOpacity onPress={onPress}>
+    <AppIcon name={name} color={color} size={size} focused={true} />
+  </TouchableOpacity>
+);
+
+export default AppButtonIcon;

--- a/src/constants/strings.ts
+++ b/src/constants/strings.ts
@@ -26,6 +26,18 @@ export const STRINGS = {
     LOADING: 'Loading...',
     EMPTY: 'No data available',
   },
+  EXCHANGE: {
+    TAB_LABEL: 'Exchange',
+    TITLE: 'Cryptocurrency Exchange',
+    FROM: 'From',
+    TO: 'To',
+    SELECT_CRYPTO: 'Select Cryptocurrency',
+    SELECT_FIAT: 'Select Fiat Currency',
+    AMOUNT: 'Amount',
+    PICKER_TITLE_CRYPTO: 'Select Cryptocurrency',
+    PICKER_TITLE_FIAT: 'Select Fiat Currency',
+    SEARCH_PLACEHOLDER: 'Search for a currency...',
+  },
   PROFILE: {
     TITLE: 'Profile',
     TAB_LABEL: 'Profile',

--- a/src/hooks/useExchange.ts
+++ b/src/hooks/useExchange.ts
@@ -1,0 +1,123 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useIsFocused } from '@react-navigation/native';
+
+import {
+  GetCoinsParams,
+  useGetCoinsQuery,
+  useGetSupportedFiatsQuery,
+} from 'services/coinGeckoApi';
+import { PickerItem } from 'types/currencyPickerModal';
+
+const USD_ID = 'usd';
+const BINANCE_ID = 'binance';
+
+const QUERY: GetCoinsParams = {
+  vs_currency: USD_ID,
+  page: 1,
+  per_page: 100,
+};
+
+const POLL_MS = 10000;
+
+export function useExchange() {
+  const isFocused = useIsFocused();
+  const [amount, setAmount] = useState('0.5');
+  const [isCryptoToFiat, setIsCryptoToFiat] = useState(true);
+  const [crypto, setCrypto] = useState<PickerItem | null>(null);
+  const [fiat, setFiat] = useState<PickerItem | null>(null);
+  const [showCryptoPicker, setShowCryptoPicker] = useState(false);
+  const [showFiatPicker, setShowFiatPicker] = useState(false);
+
+  const {
+    data: coins = [],
+    isFetching: loadingCoins,
+    error: coinsError,
+  } = useGetCoinsQuery(QUERY, {
+    pollingInterval: isFocused ? POLL_MS : 0,
+    skipPollingIfUnfocused: true,
+    refetchOnFocus: true,
+    refetchOnReconnect: true,
+  });
+
+  const {
+    data: fiats = [],
+    isFetching: loadingFiats,
+    error: fiatsError,
+  } = useGetSupportedFiatsQuery(undefined, {
+    pollingInterval: isFocused ? POLL_MS : 0,
+    skipPollingIfUnfocused: true,
+    refetchOnFocus: true,
+    refetchOnReconnect: true,
+  });
+
+  const cryptoItems: PickerItem[] = useMemo(
+    () =>
+      coins.map(c => ({
+        id: c.id,
+        symbol: c.symbol?.toUpperCase(),
+        name: c.name,
+        image: c.image,
+        price: c.current_price,
+        change24h: c.price_change_percentage_24h,
+      })),
+    [coins],
+  );
+
+  const fiatItems: PickerItem[] = useMemo(
+    () =>
+      fiats.map(f => ({
+        id: f.id,
+        symbol: f.symbol,
+        name: f.name,
+      })),
+    [fiats],
+  );
+
+  const preview = useMemo(() => {
+    const a = parseFloat(amount || '0') || 0;
+    if (!crypto || !fiat) return '—';
+    if (isCryptoToFiat) {
+      return `≈ ${
+        a && crypto.price ? (a * (crypto.price || 0)).toLocaleString() : '--'
+      } ${fiat.symbol}`;
+    }
+    return `≈ ${
+      a && crypto.price ? (a / (crypto.price || 1)).toFixed(6) : '--'
+    } ${crypto.symbol}`;
+  }, [amount, crypto, fiat, isCryptoToFiat]);
+
+  const swapDirection = () => setIsCryptoToFiat(v => !v);
+
+  useEffect(() => {
+    if (!crypto && cryptoItems.length) {
+      setCrypto(cryptoItems.find(i => i.id === BINANCE_ID) || cryptoItems[0]);
+    }
+  }, [cryptoItems, crypto]);
+
+  useEffect(() => {
+    if (!fiat && fiatItems.length) {
+      setFiat(fiatItems.find(i => i.id === USD_ID) || fiatItems[0]);
+    }
+  }, [fiatItems, fiat]);
+
+  return {
+    amount,
+    setAmount,
+    isCryptoToFiat,
+    swapDirection,
+    crypto,
+    setCrypto,
+    fiat,
+    setFiat,
+    showCryptoPicker,
+    setShowCryptoPicker,
+    showFiatPicker,
+    setShowFiatPicker,
+    cryptoItems,
+    fiatItems,
+    loadingCoins,
+    loadingFiats,
+    preview,
+    error: coinsError || fiatsError,
+  };
+}

--- a/src/navigation/stacks/AppTabs.tsx
+++ b/src/navigation/stacks/AppTabs.tsx
@@ -4,7 +4,10 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { STRINGS } from 'constants/strings';
 import { MARINER, MIDNIGHT_VAULT, WHITE } from 'constants/colors';
 import AppIcon from 'components/AppIcon';
+
+// Screens
 import HomeScreen from 'screens/Main/HomeScreen';
+import ExchangeScreen from 'screens/Main/ExchangeScreen';
 import ProfileScreen from 'screens/Main/ProfileScreen';
 
 const AppTabs = createBottomTabNavigator({
@@ -16,6 +19,16 @@ const AppTabs = createBottomTabNavigator({
         tabBarInactiveTintColor: WHITE,
         tabBarIcon: ({ size, focused }) => (
           <AppIcon name="home" size={size} focused={focused} />
+        ),
+      },
+    },
+    Exchange: {
+      screen: ExchangeScreen,
+      options: {
+        tabBarLabel: STRINGS.EXCHANGE.TAB_LABEL,
+        tabBarInactiveTintColor: WHITE,
+        tabBarIcon: ({ size, focused }) => (
+          <AppIcon name="cash" size={size} focused={focused} />
         ),
       },
     },

--- a/src/screens/Main/ExchangeScreen/components/CurrencyPickerModal/index.tsx
+++ b/src/screens/Main/ExchangeScreen/components/CurrencyPickerModal/index.tsx
@@ -1,0 +1,140 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Modal,
+  View,
+  FlatList,
+  Image,
+  TouchableOpacity,
+  KeyboardAvoidingView,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import AppText from 'components/AppText';
+import AppTextInput from 'components/AppTextInput';
+import AppButtonIcon from 'components/AppButtonIcon';
+import { STRINGS } from 'constants/strings';
+import { WHITE } from 'constants/colors';
+import { PickerItem } from 'types/currencyPickerModal';
+import { isIOS } from 'utils/platform';
+
+import styles from './styles';
+
+type Props = {
+  visible: boolean;
+  title: string;
+  items: PickerItem[];
+  onSelect: (item: PickerItem) => void;
+  onClose: () => void;
+  showPrice?: boolean;
+};
+
+const CurrencyPickerModal = ({
+  visible,
+  title,
+  items,
+  onSelect,
+  onClose,
+  showPrice,
+}: Props) => {
+  const [q, setQ] = useState('');
+
+  const filtered = useMemo(() => {
+    const s = q.trim().toLowerCase();
+    if (!s) return items;
+    return items.filter(
+      it =>
+        it.symbol.toLowerCase().includes(s) ||
+        it.name.toLowerCase().includes(s),
+    );
+  }, [q, items]);
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={onClose}
+    >
+      <SafeAreaView style={styles.backdrop}>
+        <KeyboardAvoidingView
+          behavior={isIOS ? 'padding' : 'height'}
+          style={styles.flex}
+          keyboardVerticalOffset={0}
+        >
+          <View style={styles.sheet}>
+            <View style={styles.closeButton}>
+              <AppButtonIcon
+                name="close"
+                size={30}
+                color={WHITE}
+                onPress={onClose}
+              />
+            </View>
+            <AppText variant="title" style={styles.title}>
+              {title}
+            </AppText>
+
+            <AppTextInput
+              style={styles.search}
+              placeholder={STRINGS.EXCHANGE.SEARCH_PLACEHOLDER}
+              value={q}
+              onChangeText={setQ}
+              autoFocus
+            />
+
+            <FlatList
+              data={filtered}
+              keyExtractor={i => i.id}
+              renderItem={({ item }) => (
+                <TouchableOpacity
+                  style={styles.row}
+                  onPress={() => onSelect(item)}
+                >
+                  {item.image ? (
+                    <Image source={{ uri: item.image }} style={styles.icon} />
+                  ) : (
+                    <View style={[styles.icon, styles.iconFallback]}>
+                      <AppText>{item.symbol?.[0]}</AppText>
+                    </View>
+                  )}
+                  <View style={styles.flex}>
+                    <AppText variant="body">{item.name}</AppText>
+                    <AppText variant="caption" colorType="secondary">
+                      {item.symbol}
+                    </AppText>
+                  </View>
+                  {showPrice && (
+                    <View style={styles.priceBox}>
+                      {typeof item.price === 'number' && (
+                        <AppText variant="body">
+                          ${item.price.toLocaleString()}
+                        </AppText>
+                      )}
+                      {typeof item.change24h === 'number' && (
+                        <AppText
+                          variant="caption"
+                          colorType={item.change24h >= 0 ? 'success' : 'error'}
+                          style={styles.change}
+                        >
+                          {item.change24h >= 0 ? '+' : ''}
+                          {item.change24h.toFixed(2)}%
+                        </AppText>
+                      )}
+                    </View>
+                  )}
+                </TouchableOpacity>
+              )}
+              ListEmptyComponent={
+                <View style={styles.empty}>
+                  <AppText variant="body">{STRINGS.HOME.EMPTY}</AppText>
+                </View>
+              }
+            />
+          </View>
+        </KeyboardAvoidingView>
+      </SafeAreaView>
+    </Modal>
+  );
+}
+
+export default CurrencyPickerModal;

--- a/src/screens/Main/ExchangeScreen/components/CurrencyPickerModal/styles.ts
+++ b/src/screens/Main/ExchangeScreen/components/CurrencyPickerModal/styles.ts
@@ -1,0 +1,54 @@
+import { StyleSheet } from 'react-native';
+
+import { BACKGROUND } from 'constants/colors';
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+  },
+  sheet: {
+    backgroundColor: BACKGROUND,
+    padding: 16,
+  },
+  title: {
+    marginBottom: 12,
+  },
+  search: {
+    flex: 0,
+    marginBottom: 8,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 10,
+  },
+  icon: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    marginRight: 12,
+    backgroundColor: BACKGROUND,
+  },
+  iconFallback: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  flex: {
+    flex: 1,
+  },
+  priceBox: {
+    alignItems: 'flex-end',
+  },
+  change: {
+    marginTop: 2,
+  },
+  empty: {
+    paddingVertical: 24,
+    alignItems: 'center',
+  },
+  closeButton: {
+    alignSelf: 'flex-end',
+  },
+});
+
+export default styles;

--- a/src/screens/Main/ExchangeScreen/components/SelectField/index.tsx
+++ b/src/screens/Main/ExchangeScreen/components/SelectField/index.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { View, ViewStyle, TextStyle } from 'react-native';
+
+import AppText from 'components/AppText';
+import AppButton from 'components/AppButton';
+
+type Props = {
+  label: string;
+  value?: string | null;
+  placeholder: string;
+  onPress: () => void;
+  disabled?: boolean;
+  containerStyle?: ViewStyle;
+  labelStyle?: TextStyle;
+  pillStyle?: ViewStyle;
+};
+
+const SelectField = ({
+  label,
+  value,
+  placeholder,
+  onPress,
+  disabled,
+  containerStyle,
+  labelStyle,
+  pillStyle,
+}: Props) => (
+  <View style={containerStyle}>
+    <AppText variant="body" colorType="secondary" style={labelStyle}>
+      {label}
+    </AppText>
+    <AppButton
+      variant="primary"
+      title={value || placeholder}
+      onPress={onPress}
+      style={pillStyle}
+      disabled={disabled}
+    />
+  </View>
+);
+
+export default SelectField;

--- a/src/screens/Main/ExchangeScreen/index.tsx
+++ b/src/screens/Main/ExchangeScreen/index.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { View } from 'react-native';
+
+import BaseScreen from 'components/BaseScreen';
+import AppText from 'components/AppText';
+import AppTextInput from 'components/AppTextInput';
+import AppButtonIcon from 'components/AppButtonIcon';
+import ErrorComponent from 'components/ErrorComponent';
+import { STRINGS } from 'constants/strings';
+import { MARINER } from 'constants/colors';
+import { useExchange } from 'hooks/useExchange';
+import { getErrorMessage } from 'utils/errors';
+
+import CurrencyPickerModal from './components/CurrencyPickerModal';
+import SelectField from './components/SelectField';
+import styles from './styles';
+
+function ExchangeScreen() {
+  const {
+    amount,
+    setAmount,
+    isCryptoToFiat,
+    swapDirection,
+    crypto,
+    setCrypto,
+    fiat,
+    setFiat,
+    showCryptoPicker,
+    setShowCryptoPicker,
+    showFiatPicker,
+    setShowFiatPicker,
+    cryptoItems,
+    fiatItems,
+    loadingCoins,
+    loadingFiats,
+    preview,
+    error,
+  } = useExchange();
+
+  if (error) {
+    return <ErrorComponent error={getErrorMessage(error)} />;
+  }
+
+  return (
+    <BaseScreen>
+      <AppText variant="title" style={styles.title}>
+        {STRINGS.EXCHANGE.TITLE}
+      </AppText>
+
+      <View style={styles.row}>
+        <SelectField
+          label={STRINGS.EXCHANGE.FROM}
+          value={isCryptoToFiat ? crypto?.symbol ?? null : fiat?.symbol ?? null}
+          placeholder={
+            isCryptoToFiat
+              ? STRINGS.EXCHANGE.SELECT_CRYPTO
+              : STRINGS.EXCHANGE.SELECT_FIAT
+          }
+          onPress={() =>
+            isCryptoToFiat ? setShowCryptoPicker(true) : setShowFiatPicker(true)
+          }
+          disabled={isCryptoToFiat ? loadingCoins : loadingFiats}
+          containerStyle={styles.col}
+          labelStyle={styles.label}
+          pillStyle={styles.pill}
+        />
+
+        <View style={styles.center}>
+          <AppButtonIcon
+            onPress={swapDirection}
+            name="swap-horizontal"
+            color={MARINER}
+          />
+        </View>
+
+        <SelectField
+          label={STRINGS.EXCHANGE.TO}
+          value={
+            !isCryptoToFiat ? crypto?.symbol ?? null : fiat?.symbol ?? null
+          }
+          placeholder={
+            !isCryptoToFiat
+              ? STRINGS.EXCHANGE.SELECT_CRYPTO
+              : STRINGS.EXCHANGE.SELECT_FIAT
+          }
+          onPress={() =>
+            !isCryptoToFiat
+              ? setShowCryptoPicker(true)
+              : setShowFiatPicker(true)
+          }
+          disabled={!isCryptoToFiat ? loadingCoins : loadingFiats}
+          containerStyle={styles.col}
+          labelStyle={styles.label}
+          pillStyle={styles.pill}
+        />
+      </View>
+
+      <View style={styles.inputBlock}>
+        <AppText variant="body" colorType="secondary" style={styles.label}>
+          {STRINGS.EXCHANGE.AMOUNT} (
+          {isCryptoToFiat ? crypto?.symbol : fiat?.symbol})
+        </AppText>
+        <AppTextInput
+          value={amount}
+          onChangeText={setAmount}
+          keyboardType="numeric"
+          placeholder={isCryptoToFiat ? '0.00' : '0'}
+        />
+      </View>
+
+      <View style={styles.preview}>
+        <AppText variant="subtitle">{preview}</AppText>
+      </View>
+
+      <CurrencyPickerModal
+        visible={showCryptoPicker}
+        title={STRINGS.EXCHANGE.PICKER_TITLE_CRYPTO}
+        items={cryptoItems}
+        onClose={() => setShowCryptoPicker(false)}
+        onSelect={item => {
+          setCrypto(item);
+          setShowCryptoPicker(false);
+        }}
+        showPrice
+      />
+
+      <CurrencyPickerModal
+        visible={showFiatPicker}
+        title={STRINGS.EXCHANGE.PICKER_TITLE_FIAT}
+        items={fiatItems}
+        onClose={() => setShowFiatPicker(false)}
+        onSelect={item => {
+          setFiat(item);
+          setShowFiatPicker(false);
+        }}
+      />
+    </BaseScreen>
+  );
+}
+
+export default ExchangeScreen;

--- a/src/screens/Main/ExchangeScreen/styles.ts
+++ b/src/screens/Main/ExchangeScreen/styles.ts
@@ -1,0 +1,31 @@
+import { StyleSheet } from 'react-native';
+
+const styles = StyleSheet.create({
+  title: {
+    marginBottom: 12
+  },
+  row: {
+    flexDirection: 'row',
+    gap: 12,
+    alignItems: 'flex-end',
+    marginTop: 8
+  },
+  col: { flex: 1 },
+  center: { 
+    justifyContent: 'flex-end' 
+  },
+  label: { 
+    marginBottom: 6 
+  },
+  pill: { 
+    paddingVertical: 10 
+  },
+  inputBlock: { 
+    marginTop: 18 
+  },
+  preview: { 
+    marginTop: 18 
+  },
+});
+
+export default styles;

--- a/src/services/coinGeckoApi.ts
+++ b/src/services/coinGeckoApi.ts
@@ -23,7 +23,7 @@ type FiatCurrency = {
   name: string;
 };
 
-type GetCoinsParams = {
+export type GetCoinsParams = {
   vs_currency?: 'usd' | 'eur' | 'ars' | string;
   page?: number;
   per_page?: number;

--- a/src/types/currencyPickerModal.ts
+++ b/src/types/currencyPickerModal.ts
@@ -1,0 +1,8 @@
+export type PickerItem = {
+  id: string;
+  symbol: string;
+  name: string;
+  image?: string;
+  price?: number;
+  change24h?: number;
+};

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,0 +1,3 @@
+import { Platform } from 'react-native';
+
+export const isIOS = Platform.OS === 'ios';


### PR DESCRIPTION
# Summary
Implemented a currency exchange screen allowing bidirectional conversion between cryptocurrencies (e.g., BTC, ETH, USDT) and fiat currencies (USD, EUR, ARS, PEN) using real-time data from the CoinGecko API. Users can select a crypto and a fiat currency via accessible picker modals displaying current prices and 24h variations, enter an amount, and instantly view the converted value. The screen supports switching conversion direction (crypto → fiat or fiat → crypto), includes a price auto-refresh mechanism via polling, and properly handles loading and error states to ensure a smooth user experience.

# Videos

## iOS
### Currency Switching Demonstration
https://github.com/user-attachments/assets/69098ed0-ff22-4d1e-90fa-82b40294b99f

## Android
### Automatic Price Updates via Polling
https://github.com/user-attachments/assets/486e8de6-a276-4f9c-a6bd-5d6197d4e79c



